### PR TITLE
Add support for custom log format

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,6 @@ An example supervisord.conf:
     [supervisord]
     nodaemon = true
 
-    [supervisorconsole]
-    logformat= ;; format of the logging. Available variables are `processname`, `timestamp` and `line` 
-
     [program:web]
     command = ...
     stdout_events_enabled = true
@@ -32,3 +29,13 @@ An example supervisord.conf:
     buffer_size = 100
     events = PROCESS_LOG
     result_handler = supervisor_console.events:event_handler
+
+To use a custom log format, add `--format` to the command:
+
+    command = /usr/bin/env python3 -m supervisor_console --format '-> {line}'
+
+Supported placeholders are:
+
+- `{processname}`
+- `{timestamp}`
+- `{line}`

--- a/TODO_List.md
+++ b/TODO_List.md
@@ -1,1 +1,0 @@
-* Log-Fomat cannot be set from outside

--- a/src/supervisor_console/__main__.py
+++ b/src/supervisor_console/__main__.py
@@ -1,8 +1,13 @@
 from .console import ProcessCommunicationEventHandler
+import argparse
 
 
 def main():
-    handler = ProcessCommunicationEventHandler()
+    parser = argparse.ArgumentParser(description="Forward child output to supervisord's stdout")
+    parser.add_argument('-f', '--format', nargs='?')
+    args = parser.parse_args()
+
+    handler = ProcessCommunicationEventHandler(log_format=args.format)
     handler.run_forever()
 
 

--- a/src/supervisor_console/console.py
+++ b/src/supervisor_console/console.py
@@ -16,15 +16,20 @@ class CommunicationChannels:
 
 
 class ProcessCommunicationEventHandler:
-    def __init__(self, channels: CommunicationChannels = None) -> None:
+    __log_format: str = "{processname} | {timestamp:%Y-%m-%d %H:%M:%S} | {line}"
+
+    def __init__(self, channels: CommunicationChannels = None, log_format = None) -> None:
         self.__channels = channels or CommunicationChannels()
+        self.__log_format = log_format or self.__log_format
 
     def handle_single_event(self) -> None:
         event_data: Tuple[Dict[str, str], str] = listener.wait(
             self.__channels.stdin,
             self.__channels.stdout)
         headers, payload = event_data
-        listener.send(payload, self.__channels.stdout)
+        payload_lines = payload.split('\n')
+        payload_lines = [payload_lines[0], self.__log_format, *payload_lines[1:]]
+        listener.send('\n'.join(payload_lines), self.__channels.stdout)
 
     def run_forever(self) -> NoReturn:
         while True:

--- a/src/supervisor_console/events.py
+++ b/src/supervisor_console/events.py
@@ -3,7 +3,6 @@ from sys import stderr, stdout
 from typing import Dict, BinaryIO
 from datetime import datetime
 
-__log_format: str = "{processname} | {timestamp:%Y-%m-%d %H:%M:%S} | {line}"
 __CHANNEL_MAP: Dict[str, BinaryIO] = dict(stdout=stdout, stderr=stderr)
 
 
@@ -16,14 +15,15 @@ def event_handler(event: Event, response: str) -> None:
             response = response.encode('utf-8')
         lines = response.splitlines(False)
         header_line = lines[0]
-        lines = lines[1:] 
+        log_format = lines[1].decode("utf-8")
+        lines = lines[2:] 
         headers = dict([x.split(b':') for x in header_line.split()])
         processname, channel_name = headers[b'processname'], headers[b'channel']
         channel = __CHANNEL_MAP[channel_name] \
             if channel_name in __CHANNEL_MAP.keys() else stdout
 
         timestamp: datetime = datetime.utcnow()
-        text = '\n'.join(__log_format.format(
+        text = '\n'.join(log_format.format(
             processname=processname.decode("utf-8"),
             timestamp=timestamp,
             line=line.decode("utf-8")) for line in lines)


### PR DESCRIPTION
I don't think there's an (official) way to read configs in a plugin. Other plugins (eg. superlance) use command arguments so I went that route.

Also there's no way to one-time setup the event handler I think, so I'm cheating and sending the format in each payload. This is not optimal, but gets the job done. Can be optimized further by introducing 2 payload types: one for handler setup and one for logging.